### PR TITLE
New export for cell history and perfdata (with cell indices)

### DIFF
--- a/jumper_extension/cell_history.py
+++ b/jumper_extension/cell_history.py
@@ -21,13 +21,19 @@ logger = logging.getLogger("extension")
 class CellHistory:
     def __init__(self):
         self.data = pd.DataFrame(
-            columns=["index", "raw_cell", "start_time", "end_time", "duration"]
+            columns=[
+                "cell_index",
+                "raw_cell",
+                "start_time",
+                "end_time",
+                "duration",
+            ]
         )
         self.current_cell = None
 
     def start_cell(self, raw_cell):
         self.current_cell = {
-            "index": len(self.data),
+            "cell_index": len(self.data),
             "raw_cell": raw_cell,
             "start_time": time.perf_counter(),
             "end_time": None,
@@ -56,7 +62,7 @@ class CellHistory:
     def print(self):
         for _, cell in self.data.iterrows():
             print(
-                f"Cell #{int(cell['index'])} - Duration: "
+                f"Cell #{int(cell['cell_index'])} - Duration: "
                 f"{cell['duration']:.2f}s"
             )
             print("-" * 40)
@@ -75,7 +81,7 @@ class CellHistory:
             duration = row["end_time"] - row["start_time"]
             data.append(
                 {
-                    "Cell index": row["index"],
+                    "Cell index": row["cell_index"],
                     "Duration (s)": f"{duration:.2f}",
                     "Start Time": time.strftime(
                         "%H:%M:%S", time.localtime(row["start_time"])
@@ -107,6 +113,11 @@ class CellHistory:
         # Determine format from filename extension
         _, ext = os.path.splitext(filename)
         format = ext.lower().lstrip(".")
+        
+        # Default to csv if no extension provided
+        if not format:
+            format = "csv"
+            filename += ".csv"
 
         if format == "json":
             with open(filename, "w") as f:

--- a/jumper_extension/extension_messages.py
+++ b/jumper_extension/extension_messages.py
@@ -93,8 +93,9 @@ _BASE_EXTENSION_INFO_MESSAGES = {
 
 
 def _apply_prefix(messages):
-    return {code: f"{MESSAGE_PREFIX}: {text}"
-            for code, text in messages.items()}
+    return {
+        code: f"{MESSAGE_PREFIX}: {text}" for code, text in messages.items()
+    }
 
 
 EXTENSION_ERROR_MESSAGES = _apply_prefix(_BASE_EXTENSION_ERROR_MESSAGES)

--- a/jumper_extension/monitor.py
+++ b/jumper_extension/monitor.py
@@ -60,10 +60,6 @@ class PerformanceMonitor:
             level: detect_memory_limit(level, self.uid, self.slurm_job)
             for level in self.levels
         }
-        # Backward-compatible attribute expected by tests/UI
-        self.memory = self.memory_limits.get(
-            "slurm", self.memory_limits.get("system")
-        )
 
         self.gpu_handles = []
         self.gpu_memory = 0
@@ -334,7 +330,8 @@ class PerformanceMonitor:
                 print(
                     EXTENSION_INFO_MESSAGES[
                         ExtensionInfoCode.IMPRECISE_INTERVAL
-                    ].format(interval=self.interval), end="\r"
+                    ].format(interval=self.interval),
+                    end="\r",
                 )
             else:
                 time.sleep(self.interval - time_measurement)

--- a/jumper_extension/reporter.py
+++ b/jumper_extension/reporter.py
@@ -38,7 +38,7 @@ class PerformanceReporter:
                 if len(non_short_cells) > 0:
                     # Get the last non-short cell index
                     last_valid_cell_idx = int(
-                        non_short_cells.iloc[-1]["index"]
+                        non_short_cells.iloc[-1]["cell_index"]
                     )
                     cell_range = (last_valid_cell_idx, last_valid_cell_idx)
                 else:

--- a/jumper_extension/visualizer.py
+++ b/jumper_extension/visualizer.py
@@ -204,7 +204,7 @@ class PerformanceVisualizer:
                 )
                 cell_boundaries.append(
                     {
-                        "index": cell["index"],
+                        "cell_index": cell["cell_index"],
                         "start_time": current_time,
                         "end_time": current_time + cell_duration,
                         "duration": cell_duration,
@@ -383,7 +383,7 @@ class PerformanceVisualizer:
                 draw_cell_rect(
                     cell["start_time"],
                     cell["duration"],
-                    int(cell["index"]),
+                    int(cell["cell_index"]),
                     0.4,
                 )
         else:
@@ -396,7 +396,7 @@ class PerformanceVisualizer:
             for idx, cell in cells.iterrows():
                 start_time = cell["start_time"] - self.monitor.start_time
                 draw_cell_rect(
-                    start_time, cell["duration"], int(cell["index"]), 0.5
+                    start_time, cell["duration"], int(cell["cell_index"]), 0.5
                 )
 
     def plot(
@@ -421,9 +421,9 @@ class PerformanceVisualizer:
             return
 
         # Default to all cells if no range specified
-        min_cell_idx, max_cell_idx = int(valid_cells.iloc[0]["index"]), int(
-            valid_cells.iloc[-1]["index"]
-        )
+        min_cell_idx, max_cell_idx = int(
+            valid_cells.iloc[0]["cell_index"]
+        ), int(valid_cells.iloc[-1]["cell_index"])
         if cell_range is None:
             cell_start_index = 0
             for cell_idx in range(len(valid_cells) - 1, -1, -1):
@@ -431,8 +431,8 @@ class PerformanceVisualizer:
                     cell_start_index = cell_idx
                     break
             cell_range = (
-                int(valid_cells.iloc[cell_start_index]["index"]),
-                int(valid_cells.iloc[-1]["index"]),
+                int(valid_cells.iloc[cell_start_index]["cell_index"]),
+                int(valid_cells.iloc[-1]["cell_index"]),
             )
 
         # Create interactive widgets

--- a/tests/test_data_handling.py
+++ b/tests/test_data_handling.py
@@ -146,7 +146,7 @@ def simple_history():
 def test_start_current_end_cell():
     history = CellHistory()
     history.start_cell("print('hello')")
-    assert history.current_cell["index"] == 0
+    assert history.current_cell["cell_index"] == 0
     history.end_cell(None)
     assert len(history.data) == 1
 
@@ -154,7 +154,7 @@ def test_start_current_end_cell():
 def test_view_method(simple_history, capsys, caplog):
     df = simple_history.view()
     assert len(df) == 1
-    assert df.iloc[0]["index"] == 0
+    assert df.iloc[0]["cell_index"] == 0
     assert df.iloc[0]["raw_cell"] == "print('hello')"
     assert df.iloc[0]["start_time"] < df.iloc[0]["end_time"]
 
@@ -194,7 +194,7 @@ def test_view_operations(simple_history):
     assert "end_time" in simple_history.data.columns
     assert "duration" in simple_history.data.columns
     assert "raw_cell" in simple_history.data.columns
-    assert "index" in simple_history.data.columns
+    assert "cell_index" in simple_history.data.columns
 
 
 def test_is_duration_calculated_correctly(simple_history):

--- a/tests/test_magic_commands.py
+++ b/tests/test_magic_commands.py
@@ -189,17 +189,17 @@ def test_export_and_help(ipython, mock_cpu_only):
     magics.perfmonitor_start("")
     with patch.object(magics.monitor.data, "export"):
         magics.perfmonitor_export_perfdata("")
-        magics.perfmonitor_export_perfdata("custom.csv")
+        magics.perfmonitor_export_perfdata("--file custom.csv")
     magics.perfmonitor_stop("")
 
     # Test cell history export
     with patch.object(magics.cell_history, "export"):
         magics.perfmonitor_export_cell_history("")
-        magics.perfmonitor_export_cell_history("custom.json")
+        magics.perfmonitor_export_cell_history("--file custom.json")
 
     # Test CSV export
     with patch.object(magics.cell_history, "export") as mock_export:
-        magics.perfmonitor_export_cell_history("test.csv")
+        magics.perfmonitor_export_cell_history("--file test.csv")
         mock_export.assert_called_with("test.csv")
 
     # Test help

--- a/tests/test_performance_monitor.py
+++ b/tests/test_performance_monitor.py
@@ -64,7 +64,7 @@ def test_cpu_only_and_slurm(mock_cpu_only):
         )
         monitor = PerformanceMonitor()
         assert monitor.num_gpus == 0
-        assert monitor.memory == 8.0
+        assert monitor.memory_limits["slurm"] == 8.0
         assert "gpu_util" not in monitor.metrics
 
 


### PR DESCRIPTION
Cell history and perfdata can now be exported either to file or to IPython shell. Perfdata gets cell_index column attached